### PR TITLE
Add React support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,35 @@ _The `eslint-config` suffix may be omitted because it is assumed by ESLint._
 
 ### Configurations
 
-This package contains three sharable configurations: `base`, `strict`, and `javascript`.
+This package contains the following sharable configurations:
 
-- `base` - core rules for TypeScript projects. Does not require TypeScript build. Fast.
-- `strict` - Stricter rules for TypeScript projects. Requires type checking. Slower than `base`.
+- `base` - Core rules for TypeScript node projects. Does not require TypeScript build. Fast.
+- `strict` - Stricter rules for TypeScript node projects. Requires type checking. Slower than `base`.
+- `react` - Rules for a React project
 - `javascript` - ESLint rules for JavaScript projects
 
-As of version 2.x.x, `base` is the default export for `.ts` files, and `javascript` is the default for `.js`, `.mjs`, or `.cjs` files. To request one or the other, specify which in the `eslintrc` file. For example, a `.eslintrc.json` file that uses `strict` configuration may look like this:
+As of version 2.x.x, `base` is the default export for `.ts` files, and `javascript` is the default for `.js`, `.mjs`, or `.cjs` files. To request one or the other, specify which in the `eslintrc` file. For example, a `.eslintrc.json` file that uses `react` configuration may look like this:
 
 ```json
 {
-  "extends": "@jessety/eslint-config/strict"
+  "extends": "@jessety/eslint-config/react"
+}
+```
+
+A project that uses a mix of both TypeScript and JavaScript may look like this:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["**/*.ts"],
+      "extends": "@jessety"
+    },
+    {
+      "files": ["**/*.{js,cjs,mjs}"],
+      "extends": "@jessety/eslint-config/javascript"
+    }
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "@rushstack/eslint-patch": "^1.0.9",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
-    "eslint-plugin-import": "^2.25.2"
+    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-react": "^7.28.0"
   },
   "devDependencies": {
     "@jessety/prettier-config": "^1.1.0",
-    "eslint": "^7.32.0",
+    "eslint": "^8.6.0",
     "husky": "^7.0.4",
     "jest": "^27.3.1",
     "lint-staged": "^11.2.6",

--- a/react.js
+++ b/react.js
@@ -1,0 +1,26 @@
+'use strict';
+
+require(`./patch`);
+
+module.exports = {
+  env: {
+    browser: true,
+    es2020: true
+  },
+  extends: ['./base.js'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react', '@typescript-eslint', 'import'],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 11,
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  settings: {
+    react: {
+      pragma: 'React',
+      version: 'detect'
+    }
+  }
+};


### PR DESCRIPTION
A `.eslintrc.json` file that uses `react` configuration could look like this:

```json
{
  "extends": "@jessety/eslint-config/react"
}
```